### PR TITLE
feat: implement login flow with JWT auth

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,5 @@
+import LogoutButton from '../components/LogoutButton'
+
 export const metadata = {
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000',
@@ -12,7 +14,20 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es">
-      <body style={{ fontFamily: 'Inter,system-ui' }}>{children}</body>
+      <body style={{ fontFamily: 'Inter,system-ui', margin: 0 }}>
+        <header
+          style={{
+            backgroundColor: '#111827',
+            color: '#fff',
+            padding: '8px 16px',
+            display: 'flex',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <LogoutButton />
+        </header>
+        {children}
+      </body>
     </html>
   )
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,11 +1,93 @@
 'use client'
 import { useRouter } from 'next/navigation'
-export default function Login() {
-  const r = useRouter()
+import { useState } from 'react'
+import { login } from '../../lib/api'
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      const token = await login(email, password)
+      localStorage.setItem('token', token)
+      router.push('/dashboard')
+    } catch (err) {
+      setError('Credenciales inválidas')
+    } finally {
+      setLoading(false)
+    }
+  }
   return (
-    <main style={{ padding: 24 }}>
-      <h1>Login</h1>
-      <button onClick={() => r.push('/dashboard')}>Entrar (mock)</button>
+    <main
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+        padding: 24,
+        backgroundColor: '#f3f4f6',
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+          maxWidth: 400,
+          gap: 12,
+          backgroundColor: '#fff',
+          padding: 24,
+          borderRadius: 8,
+          boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+        }}
+      >
+        <h1 style={{ textAlign: 'center', marginBottom: 12 }}>Login</h1>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          Correo
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            style={{ padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+          />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          Contraseña
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            style={{ padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+          />
+        </label>
+        {error && (
+          <p role="alert" style={{ color: '#b91c1c' }}>
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            backgroundColor: '#111827',
+            color: '#fff',
+            padding: '12px 0',
+            border: 'none',
+            borderRadius: 4,
+            cursor: 'pointer',
+          }}
+        >
+          {loading ? 'Entrando...' : 'Entrar'}
+        </button>
+      </form>
     </main>
   )
 }

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useRouter, usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
+export default function LogoutButton() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [hasToken, setHasToken] = useState(false)
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setHasToken(!!localStorage.getItem('token'))
+    }
+  }, [pathname])
+  const handleLogout = () => {
+    localStorage.removeItem('token')
+    router.push('/login')
+  }
+  if (!hasToken || pathname === '/login') return null
+  return (
+    <button
+      onClick={handleLogout}
+      style={{
+        background: 'transparent',
+        border: '1px solid #fff',
+        color: '#fff',
+        padding: '6px 12px',
+        borderRadius: 4,
+        cursor: 'pointer',
+      }}
+    >
+      Cerrar sesión
+    </button>
+  )
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,12 @@
+export async function login(email: string, password: string): Promise<string> {
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  if (!res.ok) {
+    throw new Error('Invalid credentials')
+  }
+  const data = (await res.json()) as { token: string }
+  return data.token
+}


### PR DESCRIPTION
## Summary
- replace mock login button with email/password form
- add API helper and logout button with local token storage
- basic responsive styling with accessible error handling

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a15ef173388333840cc99f6c0bcdf3