### PR TITLE
feat: add host info QR and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ Run the linter and formatter before committing:
 npm run lint
 npm run format
 ```
+
+## Escanear QR y validar POS
+
+1. En el dashboard, ve a **Instalación** para obtener un código QR con la IP, puerto y token del host.
+2. Conecta un dispositivo móvil a la misma red local y escanea el QR para abrir `http://<ip>:<port>`.
+3. Si la página carga, el POS es accesible desde la LAN y puede continuar la instalación.

--- a/app/api/host-info/route.ts
+++ b/app/api/host-info/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import os from 'os'
+
+export async function GET() {
+  const nets = os.networkInterfaces()
+  let ip = '127.0.0.1'
+  for (const name of Object.keys(nets)) {
+    const netArray = nets[name]
+    if (!netArray) continue
+    for (const net of netArray) {
+      if (net.family === 'IPv4' && !net.internal) {
+        ip = net.address
+        break
+      }
+    }
+  }
+  const port = process.env.PORT || '3000'
+  const token = process.env.PROVISION_TOKEN || 'ABC12345'
+  return NextResponse.json({ ip, port, token })
+}

--- a/app/dashboard/installation/page.tsx
+++ b/app/dashboard/installation/page.tsx
@@ -1,21 +1,57 @@
 'use client'
 import { useEffect, useState } from 'react'
 import QRCode from 'qrcode'
+
+type HostInfo = {
+  ip: string
+  port: string
+  token: string
+}
+
 export default function Installation() {
   const [img, setImg] = useState('')
+  const [host, setHost] = useState<HostInfo | null>(null)
+
   useEffect(() => {
-    QRCode.toDataURL(
-      JSON.stringify({
-        tenant: 'TENANT123',
-        provision: 'ABC12345',
-        suggested: 'http://taller.local:3000',
-      }),
-    ).then(setImg)
+    fetch('/api/host-info')
+      .then((res) => res.json())
+      .then(async (data: HostInfo) => {
+        setHost(data)
+        const qr = await QRCode.toDataURL(JSON.stringify(data))
+        setImg(qr)
+      })
   }, [])
+
+  const base = host ? `http://${host.ip}:${host.port}` : ''
+
   return (
     <main style={{ padding: 24 }}>
       <h1>Instalación — Host</h1>
       {img && <img src={img} width={200} height={200} alt="QR" />}
+      {host && (
+        <div style={{ marginTop: 24 }}>
+          <section style={{ marginBottom: 16 }}>
+            <h2>Windows</h2>
+            <p>
+              <a
+                href={`${base}/install/windows`}
+              >{`${base}/install/windows`}</a>
+            </p>
+            <pre>
+              <code>{`powershell -Command "Invoke-WebRequest -UseBasicParsing ${base}/install.ps1 -OutFile install.ps1; ./install.ps1 -Token ${host.token}"`}</code>
+            </pre>
+          </section>
+          <section>
+            <h2>Linux</h2>
+            <p>
+              <a href={`${base}/install/linux`}>{`${base}/install/linux`}</a>
+            </p>
+            <pre>
+              <code>{`curl -fsSL ${base}/install.sh | bash -s -- ${host.token}`}</code>
+            </pre>
+          </section>
+        </div>
+      )}
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- add API endpoint to expose host IP, port and provision token
- generate QR and install commands for Windows and Linux
- document scanning QR on LAN and validating POS access

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a16275927883338e358ca2089b11ee