### PR TITLE
feat: add service worker with install prompt

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import LogoutButton from '../components/LogoutButton'
+import SWRegister from './sw-register'
 
 export const metadata = {
   metadataBase: new URL(
@@ -15,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="es">
       <body style={{ fontFamily: 'Inter,system-ui', margin: 0 }}>
+        <SWRegister />
         <header
           style={{
             backgroundColor: '#111827',

--- a/app/sw-register.tsx
+++ b/app/sw-register.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect } from 'react'
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>
+}
+
+export default function SWRegister() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch((err) => console.error('SW registration failed', err))
+    }
+
+    const handleBeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
+      e.preventDefault()
+      const install = window.confirm('¿Deseas instalar esta app?')
+      if (install) {
+        e.prompt()
+      }
+    }
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+    }
+  }, [])
+
+  return null
+}
+

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,45 @@
+const CACHE_NAME = 'nexora-static-v1'
+const STATIC_ASSETS = ['/', '/icon-192.png', '/icon-512.png']
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS)))
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))))
+  )
+  self.clients.claim()
+})
+
+const OFFLINE_RESPONSE = new Response(
+  '<!DOCTYPE html><html><head><meta charset="utf-8"/><title>Offline</title></head><body><h1>Sin conexión</h1><p>Revisa tu conexión e inténtalo de nuevo.</p></body></html>',
+  { headers: { 'Content-Type': 'text/html' } }
+)
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match('/') || OFFLINE_RESPONSE)
+    )
+    return
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached
+      return fetch(event.request)
+        .then((response) => {
+          const clone = response.clone()
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone))
+          return response
+        })
+        .catch(() => caches.match('/') || OFFLINE_RESPONSE)
+    })
+  )
+})


### PR DESCRIPTION
## Summary
- add service worker with static caching and offline fallback
- register service worker and handle beforeinstallprompt for optional installation

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17214cce083338682a45eb7bc8e1d