### PR TITLE
chore: add env example and setup scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Application
+PORT=3000
+PROVISION_TOKEN=ABC12345
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+
+# PostgreSQL
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=nexora
+POSTGRES_USER=nexora
+POSTGRES_PASSWORD=secret
+
+# Redis
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=secret
+
+# S3
+S3_ENDPOINT=https://s3.amazonaws.com
+S3_REGION=us-east-1
+S3_ACCESS_KEY_ID=access_key
+S3_SECRET_ACCESS_KEY=secret_key
+S3_BUCKET=nexora-bucket
+
+# Auth
+JWT_SECRET=change_me

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage/
 
 # Env y config locales
 .env*
+!.env.example
 .vercel/
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Mock: login, dashboard, productos, suscripciones, instalación con QR.
 
+## Configuración
+
+1. Copia el archivo de ejemplo y crea tu propio `.env`:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Edita `.env` y ajusta las credenciales de PostgreSQL, Redis, S3 y `JWT_SECRET` según tu entorno.
+
 ## Code quality
 
 Run the linter and formatter before committing:

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Installing Docker..."
+  curl -fsSL https://get.docker.com | sh
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Installing Docker Compose plugin..."
+  DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+  mkdir -p "$DOCKER_CONFIG/cli-plugins"
+  curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o "$DOCKER_CONFIG/cli-plugins/docker-compose"
+  chmod +x "$DOCKER_CONFIG/cli-plugins/docker-compose"
+fi
+
+docker compose up -d

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Host 'Installing Docker Desktop...'
+    $installer = "$env:TEMP/DockerDesktopInstaller.exe"
+    Invoke-WebRequest 'https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe' -OutFile $installer
+    Start-Process -FilePath $installer -Wait -ArgumentList 'install', '--quiet'
+}
+
+docker compose up -d


### PR DESCRIPTION
## Summary
- add `.env.example` with PostgreSQL, Redis, S3 and auth variables
- add Linux and Windows setup scripts to install Docker and run `docker compose`
- document environment setup in README and allow `.env.example` in gitignore

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17c142e088333b2c5089059f9b21f