### PR TITLE
feat: add offline outbox with service worker sync

### DIFF
--- a/app/sw-register.tsx
+++ b/app/sw-register.tsx
@@ -11,6 +11,15 @@ export default function SWRegister() {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker
         .register('/sw.js')
+        .then(() => {
+          navigator.serviceWorker.ready.then((reg) => {
+            if ('sync' in reg) {
+              reg.sync
+                .register('sync-outbox')
+                .catch((err) => console.error('Sync registration failed', err))
+            }
+          })
+        })
         .catch((err) => console.error('SW registration failed', err))
     }
 
@@ -30,4 +39,3 @@ export default function SWRegister() {
 
   return null
 }
-

--- a/lib/outbox.ts
+++ b/lib/outbox.ts
@@ -1,0 +1,51 @@
+const DB_NAME = 'nexora-outbox'
+const STORE_NAME = 'requests'
+
+export interface OutboxRequest {
+  id?: number
+  url: string
+  method: string
+  headers?: [string, string][]
+  body?: string
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1)
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true })
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function addRequest(data: Omit<OutboxRequest, 'id'>) {
+  const db = await openDB()
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+    tx.objectStore(STORE_NAME).add(data)
+  })
+}
+
+export async function getRequests() {
+  const db = await openDB()
+  return new Promise<OutboxRequest[]>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const req = tx.objectStore(STORE_NAME).getAll()
+    req.onsuccess = () => resolve(req.result as OutboxRequest[])
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function removeRequest(id: number) {
+  const db = await openDB()
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+    tx.objectStore(STORE_NAME).delete(id)
+  })
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,83 @@
 const CACHE_NAME = 'nexora-static-v1'
 const STATIC_ASSETS = ['/', '/icon-192.png', '/icon-512.png']
 
+const DB_NAME = 'nexora-outbox'
+const STORE_NAME = 'requests'
+const RETRIES = 3
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1)
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true })
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+function addRequest(data) {
+  return openDB().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite')
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error)
+        tx.objectStore(STORE_NAME).add(data)
+      })
+  )
+}
+
+function getRequests() {
+  return openDB().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly')
+        const req = tx.objectStore(STORE_NAME).getAll()
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error)
+      })
+  )
+}
+
+function removeRequest(id) {
+  return openDB().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite')
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error)
+        tx.objectStore(STORE_NAME).delete(id)
+      })
+  )
+}
+
+function delay(ms) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+async function processOutbox() {
+  const items = await getRequests()
+  for (const item of items) {
+    let sent = false
+    for (let i = 0; i < RETRIES && !sent; i++) {
+      try {
+        await fetch(item.url, {
+          method: item.method,
+          headers: item.headers,
+          body: item.body,
+        })
+        sent = true
+      } catch (err) {
+        await delay(1000 * (i + 1))
+      }
+    }
+    if (sent && item.id !== undefined) {
+      await removeRequest(item.id)
+    }
+  }
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS)))
   self.skipWaiting()
@@ -21,25 +98,53 @@ const OFFLINE_RESPONSE = new Response(
 )
 
 self.addEventListener('fetch', (event) => {
-  if (event.request.method !== 'GET') return
+  const req = event.request
 
-  if (event.request.mode === 'navigate') {
+  if (req.method !== 'GET') {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match('/') || OFFLINE_RESPONSE)
+      fetch(req.clone()).catch(async () => {
+        const body = await req.clone().text()
+        await addRequest({
+          url: req.url,
+          method: req.method,
+          headers: Array.from(req.headers.entries()),
+          body,
+        })
+        if ('sync' in self.registration) {
+          await self.registration.sync.register('sync-outbox')
+        }
+        return new Response(JSON.stringify({ stored: true }), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 202,
+        })
+      })
+    )
+    return
+  }
+
+  if (req.mode === 'navigate') {
+    event.respondWith(
+      fetch(req).catch(() => caches.match('/') || OFFLINE_RESPONSE)
     )
     return
   }
 
   event.respondWith(
-    caches.match(event.request).then((cached) => {
+    caches.match(req).then((cached) => {
       if (cached) return cached
-      return fetch(event.request)
+      return fetch(req)
         .then((response) => {
           const clone = response.clone()
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone))
+          caches.open(CACHE_NAME).then((cache) => cache.put(req, clone))
           return response
         })
         .catch(() => caches.match('/') || OFFLINE_RESPONSE)
     })
   )
+})
+
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'sync-outbox') {
+    event.waitUntil(processOutbox())
+  }
 })


### PR DESCRIPTION
## Summary
- queue failed requests in an IndexedDB outbox
- add background sync with retry logic in service worker
- register service worker and trigger sync when ready

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19b8f1ad48333b596b8064b0af704