### PR TITLE
feat: add dashboard modules for devices, users, and support

### DIFF
--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { renameDevice, revokeDevice } from '../../../../lib/devices'
+
+export async function PUT(
+  request: NextRequest,
+  context: any,
+) {
+  const { name } = await request.json()
+  if (!name) {
+    return NextResponse.json({ message: 'Nombre requerido' }, { status: 400 })
+  }
+  const device = renameDevice(context.params.id, name)
+  if (!device) {
+    return NextResponse.json({ message: 'No encontrado' }, { status: 404 })
+  }
+  return NextResponse.json(device)
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  context: any,
+) {
+  revokeDevice(context.params.id)
+  return NextResponse.json({ success: true })
+}

--- a/app/api/devices/route.ts
+++ b/app/api/devices/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+import { listDevices } from '../../../lib/devices'
+
+export async function GET() {
+  return NextResponse.json(listDevices())
+}

--- a/app/api/support/route.ts
+++ b/app/api/support/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { addTicket, listTickets } from '../../../lib/support'
+
+export async function GET() {
+  return NextResponse.json(listTickets())
+}
+
+export async function POST(req: Request) {
+  const { subject, message } = await req.json()
+  if (!subject || !message) {
+    return NextResponse.json({ message: 'Datos inválidos' }, { status: 400 })
+  }
+  const ticket = addTicket(subject, message)
+  return NextResponse.json(ticket, { status: 201 })
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { removeInvite } from '../../../../lib/users'
+
+export async function DELETE(
+  _request: NextRequest,
+  context: any,
+) {
+  removeInvite(context.params.id)
+  return NextResponse.json({ success: true })
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { addInvite, listInvites } from '../../../lib/users'
+
+export async function GET() {
+  return NextResponse.json(listInvites())
+}
+
+export async function POST(req: Request) {
+  const { email, role } = await req.json()
+  if (!email || !role) {
+    return NextResponse.json({ message: 'Datos inválidos' }, { status: 400 })
+  }
+  const invite = addInvite(email, role)
+  return NextResponse.json(invite, { status: 201 })
+}

--- a/app/dashboard/devices/page.tsx
+++ b/app/dashboard/devices/page.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Device {
+  id: string
+  name: string
+}
+
+export default function Devices() {
+  const [devices, setDevices] = useState<Device[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  async function fetchDevices() {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch('/api/devices')
+      if (!res.ok) {
+        throw new Error('Error al cargar dispositivos')
+      }
+      const data = (await res.json()) as Device[]
+      setDevices(data)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Error desconocido'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchDevices()
+  }, [])
+
+  const rename = async (id: string) => {
+    const name = prompt('Nuevo nombre del dispositivo')
+    if (!name) return
+    try {
+      const res = await fetch(`/api/devices/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      })
+      if (!res.ok) {
+        throw new Error('No se pudo renombrar')
+      }
+      fetchDevices()
+    } catch {
+      setError('No se pudo renombrar dispositivo')
+    }
+  }
+
+  const revoke = async (id: string) => {
+    try {
+      const res = await fetch(`/api/devices/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        throw new Error('No se pudo revocar')
+      }
+      fetchDevices()
+    } catch {
+      setError('No se pudo revocar dispositivo')
+    }
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Dispositivos</h1>
+      {loading && <p>Cargando...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {!loading && !error && devices.length === 0 && <p>No hay dispositivos</p>}
+      <ul style={{ display: 'grid', gap: 16 }}>
+        {devices.map((d) => (
+          <li
+            key={d.id}
+            style={{ border: '1px solid #ccc', padding: 16, borderRadius: 8 }}
+          >
+            <strong>{d.name}</strong>
+            <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
+              <button onClick={() => rename(d.id)}>Renombrar</button>
+              <button onClick={() => revoke(d.id)}>Revocar</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -12,6 +12,15 @@ export default function Dashboard() {
         <li>
           <a href="/dashboard/installation">Instalación</a>
         </li>
+        <li>
+          <a href="/dashboard/devices">Dispositivos</a>
+        </li>
+        <li>
+          <a href="/dashboard/users">Usuarios</a>
+        </li>
+        <li>
+          <a href="/dashboard/support">Soporte</a>
+        </li>
       </ul>
     </main>
   )

--- a/app/dashboard/support/page.tsx
+++ b/app/dashboard/support/page.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Ticket {
+  id: string
+  subject: string
+  message: string
+}
+
+export default function Support() {
+  const [tickets, setTickets] = useState<Ticket[]>([])
+  const [subject, setSubject] = useState('')
+  const [message, setMessage] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  async function fetchTickets() {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch('/api/support')
+      if (!res.ok) {
+        throw new Error('Error al cargar tickets')
+      }
+      const data = (await res.json()) as Ticket[]
+      setTickets(data)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Error desconocido'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchTickets()
+  }, [])
+
+  const submit = async () => {
+    try {
+      setError(null)
+      const res = await fetch('/api/support', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subject, message }),
+      })
+      if (!res.ok) {
+        throw new Error('No se pudo enviar el ticket')
+      }
+      setSubject('')
+      setMessage('')
+      fetchTickets()
+    } catch {
+      setError('No se pudo enviar el ticket')
+    }
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Soporte</h1>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <div style={{ marginBottom: 16, display: 'grid', gap: 8 }}>
+        <input
+          type="text"
+          placeholder="Asunto"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+        />
+        <textarea
+          placeholder="Mensaje"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button onClick={submit}>Enviar</button>
+      </div>
+      {loading && <p>Cargando...</p>}
+      {!loading && tickets.length === 0 && <p>No hay tickets</p>}
+      <ul style={{ display: 'grid', gap: 16 }}>
+        {tickets.map((t) => (
+          <li
+            key={t.id}
+            style={{ border: '1px solid #ccc', padding: 16, borderRadius: 8 }}
+          >
+            <strong>{t.subject}</strong>
+            <p>{t.message}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/app/dashboard/users/page.tsx
+++ b/app/dashboard/users/page.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { Role } from '../../../lib/auth/roles'
+
+interface Invite {
+  id: string
+  email: string
+  role: Role
+}
+
+export default function Users() {
+  const [invites, setInvites] = useState<Invite[]>([])
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState<Role>('user')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  async function fetchInvites() {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch('/api/users')
+      if (!res.ok) {
+        throw new Error('Error al cargar invitaciones')
+      }
+      const data = (await res.json()) as Invite[]
+      setInvites(data)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Error desconocido'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchInvites()
+  }, [])
+
+  const invite = async () => {
+    try {
+      setError(null)
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, role }),
+      })
+      if (!res.ok) {
+        throw new Error('No se pudo enviar la invitación')
+      }
+      setEmail('')
+      setRole('user')
+      fetchInvites()
+    } catch {
+      setError('No se pudo enviar la invitación')
+    }
+  }
+
+  const remove = async (id: string) => {
+    try {
+      const res = await fetch(`/api/users/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        throw new Error('No se pudo eliminar')
+      }
+      fetchInvites()
+    } catch {
+      setError('No se pudo eliminar invitación')
+    }
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Usuarios</h1>
+      {loading && <p>Cargando...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <div style={{ marginBottom: 16, display: 'flex', gap: 8 }}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <select value={role} onChange={(e) => setRole(e.target.value as Role)}>
+          <option value="user">Usuario</option>
+          <option value="admin">Admin</option>
+        </select>
+        <button onClick={invite}>Invitar</button>
+      </div>
+      {!loading && !error && invites.length === 0 && <p>No hay invitaciones</p>}
+      <ul style={{ display: 'grid', gap: 16 }}>
+        {invites.map((i) => (
+          <li
+            key={i.id}
+            style={{ border: '1px solid #ccc', padding: 16, borderRadius: 8 }}
+          >
+            <div>{i.email}</div>
+            <div>Rol: {i.role}</div>
+            <button onClick={() => remove(i.id)}>Eliminar</button>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/lib/devices.ts
+++ b/lib/devices.ts
@@ -1,0 +1,25 @@
+export interface Device {
+  id: string
+  name: string
+}
+
+let devices: Device[] = [
+  { id: 'dev1', name: 'Teléfono' },
+  { id: 'dev2', name: 'Portátil' },
+]
+
+export function listDevices() {
+  return devices
+}
+
+export function renameDevice(id: string, name: string) {
+  const device = devices.find((d) => d.id === id)
+  if (device) {
+    device.name = name
+  }
+  return device
+}
+
+export function revokeDevice(id: string) {
+  devices = devices.filter((d) => d.id !== id)
+}

--- a/lib/support.ts
+++ b/lib/support.ts
@@ -1,0 +1,21 @@
+export interface Ticket {
+  id: string
+  subject: string
+  message: string
+}
+
+let tickets: Ticket[] = []
+
+export function listTickets() {
+  return tickets
+}
+
+export function addTicket(subject: string, message: string) {
+  const ticket: Ticket = {
+    id: Math.random().toString(36).slice(2),
+    subject,
+    message,
+  }
+  tickets.push(ticket)
+  return ticket
+}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,0 +1,27 @@
+import type { Role } from './auth/roles'
+
+export interface Invite {
+  id: string
+  email: string
+  role: Role
+}
+
+let invites: Invite[] = []
+
+export function listInvites() {
+  return invites
+}
+
+export function addInvite(email: string, role: Role) {
+  const invite: Invite = {
+    id: Math.random().toString(36).slice(2),
+    email,
+    role,
+  }
+  invites.push(invite)
+  return invite
+}
+
+export function removeInvite(id: string) {
+  invites = invites.filter((i) => i.id !== id)
+}


### PR DESCRIPTION
## Summary
- add devices, users and support links in dashboard
- implement APIs and pages to manage devices and user invitations
- add basic support ticket form and listing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1a57507248333a4981dcdffe9173d