### PR TITLE
feat: add WhatsApp share helper

### DIFF
--- a/components/QuoteShareButton.tsx
+++ b/components/QuoteShareButton.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { buildWhatsAppShare } from '../lib/share'
+interface QuoteShareButtonProps {
+  quoteId: string
+  token: string
+  total: number
+}
+export default function QuoteShareButton({ quoteId, token, total }: QuoteShareButtonProps) {
+  const href = buildWhatsAppShare(quoteId, token, total)
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="bg-green-600 text-white py-1.5 px-3 rounded"
+    >
+      Compartir por WhatsApp
+    </a>
+  )
+}

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,0 +1,11 @@
+export function buildWhatsAppShare(quoteId: string, token: string, total: number) {
+  const base = process.env.NEXT_PUBLIC_PUBLIC_BASE_EXTERNAL || process.env.NEXT_PUBLIC_PUBLIC_BASE_LAN || ''
+  const approveBase = (base || '').replace(/\/$/, '')
+  const url = `${approveBase}/approve/${token}`
+  const msg =
+    `Hola 👋, te compartimos la cotización ${quoteId}. Total estimado: $${total.toFixed(2)} MXN.` +
+    `
+
+Revisa y autoriza aquí: ${url}`
+  return `https://wa.me/?text=${encodeURIComponent(msg)}`
+}


### PR DESCRIPTION
## Summary
- add buildWhatsAppShare util to compose WhatsApp share links
- provide QuoteShareButton component using the share builder

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1a76e221c8333ac36404994e20272