### PR TITLE
Add product and subscription API routes

### DIFF
--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,20 +1,6 @@
 import { NextResponse } from 'next/server'
 import { verifyToken } from '../../../lib/auth/token'
-
-const plans = [
-  {
-    id: 'basic',
-    name: 'Basic',
-    price: 10,
-    benefits: ['Característica A'],
-  },
-  {
-    id: 'pro',
-    name: 'Pro',
-    price: 20,
-    benefits: ['Característica A', 'Característica B'],
-  },
-]
+import { listProducts } from '../../../lib/products'
 
 export async function GET(req: Request) {
   const auth = req.headers.get('authorization')
@@ -27,5 +13,5 @@ export async function GET(req: Request) {
   } catch {
     return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
   }
-  return NextResponse.json(plans)
+  return NextResponse.json(listProducts())
 }

--- a/app/api/subscriptions/route.ts
+++ b/app/api/subscriptions/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server'
+import Stripe from 'stripe'
 import { verifyToken } from '../../../lib/auth/token'
-import { getSubscription } from '../../../lib/subscriptions'
+import { getSubscription, setSubscription } from '../../../lib/subscriptions'
+
+export const runtime = 'nodejs'
 
 export async function GET(req: Request) {
   const auth = req.headers.get('authorization')
@@ -16,4 +19,32 @@ export async function GET(req: Request) {
   }
   const sub = getSubscription(payload.sub)
   return NextResponse.json(sub || null)
+}
+
+export async function POST(req: Request) {
+  const auth = req.headers.get('authorization')
+  if (!auth) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+  }
+  const token = auth.split(' ')[1]
+  let payload
+  try {
+    payload = verifyToken(token)
+  } catch {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { sessionId } = (await req.json()) as { sessionId: string }
+  const secret = process.env.STRIPE_SECRET_KEY
+  if (!secret) {
+    return NextResponse.json({ message: 'Stripe not configured' }, { status: 500 })
+  }
+  const stripe = new Stripe(secret)
+  const session = await stripe.checkout.sessions.retrieve(sessionId)
+  const planId = session.metadata?.planId
+  if (!planId) {
+    return NextResponse.json({ message: 'Invalid session' }, { status: 400 })
+  }
+  setSubscription(Number(payload.sub), planId)
+  return NextResponse.json({ success: true })
 }

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,0 +1,35 @@
+export interface Product {
+  id: string
+  name: string
+  status: string
+  createdAt: string
+  updatedAt: string
+}
+
+const products: Product[] = [
+  {
+    id: 'prod1',
+    name: 'Producto 1',
+    status: 'active',
+    createdAt: new Date('2024-01-01').toISOString(),
+    updatedAt: new Date('2024-01-02').toISOString(),
+  },
+  {
+    id: 'prod2',
+    name: 'Producto 2',
+    status: 'inactive',
+    createdAt: new Date('2024-02-01').toISOString(),
+    updatedAt: new Date('2024-02-03').toISOString(),
+  },
+  {
+    id: 'prod3',
+    name: 'Producto 3',
+    status: 'active',
+    createdAt: new Date('2024-03-01').toISOString(),
+    updatedAt: new Date('2024-03-05').toISOString(),
+  },
+]
+
+export function listProducts() {
+  return products
+}


### PR DESCRIPTION
## Summary
- add API route to list products
- secure plans API and add subscription confirmation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1ad03649483338bd57ef74c4cef19