### PR TITLE
feat: animated landing page with Anime.js

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,68 @@
+'use client'
+
+import { useEffect } from 'react'
+import { animate, stagger } from 'animejs'
+
 export default function Home() {
+  useEffect(() => {
+    animate('.fade-in', {
+      opacity: [0, 1],
+      translateY: [20, 0],
+      easing: 'easeOutQuad',
+      duration: 1000,
+      delay: stagger(200),
+    })
+  }, [])
+
   return (
-    <main style={{ padding: 24 }}>
-      <h1>Nexora Portal</h1>
-      <a href="/dashboard">Ir al Dashboard</a>
+    <main className="bg-light text-dark min-h-screen">
+      <section className="fade-in opacity-0 text-center py-20 px-4">
+        <h1 className="text-5xl font-bold mb-4">Nexora POS</h1>
+        <p className="text-lg mb-8">
+          Plataforma local con PWA y portal en la nube para la gestión de tu taller.
+        </p>
+        <a
+          href="/login"
+          className="bg-primary text-white px-8 py-3 rounded hover:bg-secondary transition-colors"
+        >
+          Ingresar
+        </a>
+      </section>
+
+      <section className="px-4 py-16">
+        <h2 className="fade-in opacity-0 text-3xl font-semibold text-center mb-10">
+          Características
+        </h2>
+        <div className="grid gap-8 md:grid-cols-3">
+          <div className="fade-in opacity-0 bg-light text-dark p-6 rounded shadow border border-primary">
+            <h3 className="text-xl font-semibold mb-2">PWA offline</h3>
+            <p>
+              Instálala en cualquier dispositivo y sigue operando sin conexión en la red
+              local.
+            </p>
+          </div>
+          <div className="fade-in opacity-0 bg-light text-dark p-6 rounded shadow border border-primary">
+            <h3 className="text-xl font-semibold mb-2">Licencias seguras</h3>
+            <p>
+              Suscripciones con periodo de gracia y modo limitado al expirar para proteger
+              tu negocio.
+            </p>
+          </div>
+          <div className="fade-in opacity-0 bg-light text-dark p-6 rounded shadow border border-primary">
+            <h3 className="text-xl font-semibold mb-2">Aprobación externa</h3>
+            <p>
+              Comparte cotizaciones mediante un túnel seguro para que tus clientes las
+              autoricen desde cualquier lugar.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <footer className="fade-in opacity-0 bg-dark text-light text-center py-8">
+        <p className="text-sm">
+          &copy; {new Date().getFullYear()} Nexora. Todos los derechos reservados.
+        </p>
+      </footer>
     </main>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "nexora-portal",
       "dependencies": {
+        "animejs": "^4.1.3",
         "jose": "^5.9.6",
         "jsonwebtoken": "^9.0.2",
         "next": "latest",
@@ -1914,6 +1915,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/animejs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/animejs/-/animejs-4.1.3.tgz",
+      "integrity": "sha512-4XzlIsQsku1ycSPzchxxT0N+ohEMZObG71nOSBBkZoV4sgQvtXa/qAANkFpTE6pegdV8JnIBZiB0LfdxNoRNMw==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "jsonwebtoken": "^9.0.2",
+    "animejs": "^4.1.3",
     "jose": "^5.9.6",
+    "jsonwebtoken": "^9.0.2",
     "next": "latest",
     "qrcode": "1.5.3",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary
- install Anime.js and create client-side landing page
- animate hero, features and footer with fade-in effects
- apply Tailwind palette across buttons, text and backgrounds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a235f32ae083339a0f73902ec02063